### PR TITLE
strengthen higher ranked where-bound to avoid breakage

### DIFF
--- a/src/geometries/contour/difference.rs
+++ b/src/geometries/contour/difference.rs
@@ -65,7 +65,7 @@ where
         + for<'a> From<(&'a [&'a Segment<Scalar>], &'a [&'a Segment<Scalar>])>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
     Segment<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Contour<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Segment<Scalar>: Bounded<&'a Scalar>,
 {
@@ -160,7 +160,7 @@ where
         + for<'a> From<(&'a [&'a Segment<Scalar>], &'a [&'a Polygon<Scalar>])>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
     Segment<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Contour<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Multipolygon<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Polygon<Scalar>: Bounded<&'a Scalar>,
@@ -258,7 +258,7 @@ where
         + for<'a> From<(&'a [&'a Segment<Scalar>], &'a [&'a Segment<Scalar>])>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
     Segment<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Contour<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Segment<Scalar>: Bounded<&'a Scalar>,
 {
@@ -353,7 +353,7 @@ where
         + for<'a> From<(&'a [&'a Segment<Scalar>], &'a Polygon<Scalar>)>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
     Segment<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Contour<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Polygon<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Segment<Scalar>: Bounded<&'a Scalar>,
@@ -429,7 +429,7 @@ impl<Scalar: PartialEq> Difference<&Segment<Scalar>> for &Contour<Scalar>
 where
     Point<Scalar>: Clone + PartialOrd,
     Segment<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Contour<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Point<Scalar>:
         IntersectCrossingSegments<Output = Point<Scalar>> + Orient,

--- a/src/geometries/contour/intersection.rs
+++ b/src/geometries/contour/intersection.rs
@@ -58,7 +58,7 @@ where
         + ReduceEvents<Output = Vec<Segment<Scalar>>>
         + for<'a> From<(&'a [&'a Segment<Scalar>], &'a [&'a Segment<Scalar>])>,
     Point<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Point<Scalar>: Orient,
     for<'a> &'a Segment<Scalar>: Bounded<&'a Scalar>,
 {
@@ -89,7 +89,7 @@ where
         + ReduceEvents<Output = Vec<Segment<Scalar>>>
         + for<'a> From<(&'a [&'a Segment<Scalar>], &'a [&'a Polygon<Scalar>])>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Contour<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Multipolygon<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Polygon<Scalar>: Bounded<&'a Scalar>,
@@ -184,7 +184,7 @@ where
         + ReduceEvents<Output = Vec<Segment<Scalar>>>
         + for<'a> From<(&'a [&'a Segment<Scalar>], &'a [&'a Segment<Scalar>])>,
     Point<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Point<Scalar>: Orient,
     for<'a> &'a Segment<Scalar>: Bounded<&'a Scalar>,
 {
@@ -215,7 +215,7 @@ where
         + ReduceEvents<Output = Vec<Segment<Scalar>>>
         + for<'a> From<(&'a [&'a Segment<Scalar>], &'a Polygon<Scalar>)>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Contour<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Polygon<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Segment<Scalar>: Bounded<&'a Scalar>,
@@ -283,7 +283,7 @@ impl<Scalar> Intersection<&Segment<Scalar>> for &Contour<Scalar>
 where
     Scalar: PartialEq,
     Point<Scalar>: Clone + Ord,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Point<Scalar>: Orient,
     for<'a> &'a Segment<Scalar>: Bounded<&'a Scalar>,
 {

--- a/src/geometries/contour/symmetric_difference.rs
+++ b/src/geometries/contour/symmetric_difference.rs
@@ -61,7 +61,7 @@ where
         + for<'a> From<(&'a [&'a Segment<Scalar>], &'a [&'a Segment<Scalar>])>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
     Segment<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Contour<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Segment<Scalar>: Bounded<&'a Scalar>,
 {
@@ -163,7 +163,7 @@ where
         + for<'a> From<(&'a [&'a Segment<Scalar>], &'a [&'a Segment<Scalar>])>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
     Segment<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Multisegment<Scalar>:
         Bounded<&'a Scalar> + Multisegmental<IndexSegment = Segment<Scalar>>,
     for<'a> &'a Contour<Scalar>: Bounded<&'a Scalar>,
@@ -269,7 +269,7 @@ where
         + for<'a> From<(&'a [&'a Segment<Scalar>], &'a Segment<Scalar>)>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
     Segment<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Contour<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Segment<Scalar>: Bounded<&'a Scalar>,
 {

--- a/src/geometries/contour/union.rs
+++ b/src/geometries/contour/union.rs
@@ -63,7 +63,7 @@ where
         + for<'a> From<(&'a [&'a Segment<Scalar>], &'a [&'a Segment<Scalar>])>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
     Segment<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Contour<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Segment<Scalar>: Bounded<&'a Scalar>,
 {
@@ -166,7 +166,7 @@ where
         + for<'a> From<(&'a [&'a Segment<Scalar>], &'a [&'a Segment<Scalar>])>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
     Segment<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Contour<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Multisegment<Scalar>:
         Bounded<&'a Scalar> + Multisegmental<IndexSegment = Segment<Scalar>>,
@@ -266,7 +266,7 @@ impl<Scalar: PartialEq> Union<&Segment<Scalar>> for &Contour<Scalar>
 where
     Point<Scalar>: Clone + Ord,
     Segment<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Contour<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Point<Scalar>:
         IntersectCrossingSegments<Output = Point<Scalar>> + Orient,

--- a/src/geometries/multipolygon/difference.rs
+++ b/src/geometries/multipolygon/difference.rs
@@ -60,7 +60,7 @@ where
         + for<'a> From<(&'a [&'a Polygon<Scalar>], &'a [&'a Polygon<Scalar>])>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
     Polygon<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Multipolygon<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Polygon<Scalar>: Bounded<&'a Scalar>,
 {
@@ -147,7 +147,7 @@ where
         + for<'a> From<(&'a [&'a Polygon<Scalar>], &'a Polygon<Scalar>)>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
     Polygon<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Multipolygon<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Polygon<Scalar>: Bounded<&'a Scalar>,
 {

--- a/src/geometries/multipolygon/intersection.rs
+++ b/src/geometries/multipolygon/intersection.rs
@@ -54,7 +54,7 @@ where
         + ReduceEvents<Output = Vec<Polygon<Scalar>>>
         + for<'a> From<(&'a [&'a Polygon<Scalar>], &'a [&'a Polygon<Scalar>])>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Multipolygon<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Polygon<Scalar>: Bounded<&'a Scalar>,
 {
@@ -139,7 +139,7 @@ where
         + ReduceEvents<Output = Vec<Segment<Scalar>>>
         + for<'a> From<(&'a [&'a Polygon<Scalar>], &'a [&'a Segment<Scalar>])>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Contour<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Multipolygon<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Polygon<Scalar>: Bounded<&'a Scalar>,
@@ -235,7 +235,7 @@ where
         + ReduceEvents<Output = Vec<Segment<Scalar>>>
         + for<'a> From<(&'a [&'a Polygon<Scalar>], &'a [&'a Segment<Scalar>])>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Multipolygon<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Multisegment<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Polygon<Scalar>: Bounded<&'a Scalar>,
@@ -331,7 +331,7 @@ where
         + ReduceEvents<Output = Vec<Polygon<Scalar>>>
         + for<'a> From<(&'a [&'a Polygon<Scalar>], &'a Polygon<Scalar>)>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Multipolygon<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Polygon<Scalar>: Bounded<&'a Scalar>,
 {
@@ -394,7 +394,7 @@ where
         + ReduceEvents<Output = Vec<Segment<Scalar>>>
         + for<'a> From<(&'a [&'a Polygon<Scalar>], &'a Segment<Scalar>)>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Multipolygon<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Polygon<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Segment<Scalar>: Bounded<&'a Scalar>,

--- a/src/geometries/multipolygon/symmetric_difference.rs
+++ b/src/geometries/multipolygon/symmetric_difference.rs
@@ -59,7 +59,7 @@ where
         + for<'a> From<(&'a [&'a Polygon<Scalar>], &'a [&'a Polygon<Scalar>])>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
     Polygon<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Multipolygon<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Polygon<Scalar>: Bounded<&'a Scalar>,
 {
@@ -158,7 +158,7 @@ where
         + for<'a> From<(&'a [&'a Polygon<Scalar>], &'a Polygon<Scalar>)>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
     Polygon<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Multipolygon<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Polygon<Scalar>: Bounded<&'a Scalar>,
 {

--- a/src/geometries/multipolygon/union.rs
+++ b/src/geometries/multipolygon/union.rs
@@ -59,7 +59,7 @@ where
         + for<'a> From<(&'a [&'a Polygon<Scalar>], &'a [&'a Polygon<Scalar>])>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
     Polygon<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Multipolygon<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Polygon<Scalar>: Bounded<&'a Scalar>,
 {
@@ -159,7 +159,7 @@ where
         + for<'a> From<(&'a [&'a Polygon<Scalar>], &'a Polygon<Scalar>)>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
     Polygon<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Multipolygon<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Polygon<Scalar>: Bounded<&'a Scalar>,
 {

--- a/src/geometries/multisegment/difference.rs
+++ b/src/geometries/multisegment/difference.rs
@@ -65,7 +65,7 @@ where
         + for<'a> From<(&'a [&'a Segment<Scalar>], &'a [&'a Segment<Scalar>])>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
     Segment<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Multisegment<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Segment<Scalar>: Bounded<&'a Scalar>,
 {
@@ -161,7 +161,7 @@ where
         + for<'a> From<(&'a [&'a Segment<Scalar>], &'a [&'a Segment<Scalar>])>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
     Segment<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Multisegment<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Segment<Scalar>: Bounded<&'a Scalar>,
 {
@@ -256,7 +256,7 @@ where
         + for<'a> From<(&'a [&'a Segment<Scalar>], &'a [&'a Polygon<Scalar>])>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
     Segment<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Multipolygon<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Multisegment<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Polygon<Scalar>: Bounded<&'a Scalar>,
@@ -354,7 +354,7 @@ where
         + for<'a> From<(&'a [&'a Segment<Scalar>], &'a Polygon<Scalar>)>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
     Segment<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Multisegment<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Polygon<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Segment<Scalar>: Bounded<&'a Scalar>,
@@ -430,7 +430,7 @@ impl<Scalar: PartialEq> Difference<&Segment<Scalar>> for &Multisegment<Scalar>
 where
     Point<Scalar>: Clone + PartialOrd,
     Segment<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Multisegment<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Point<Scalar>:
         IntersectCrossingSegments<Output = Point<Scalar>> + Orient,

--- a/src/geometries/multisegment/intersection.rs
+++ b/src/geometries/multisegment/intersection.rs
@@ -61,7 +61,7 @@ where
         + ReduceEvents<Output = Vec<Segment<Scalar>>>
         + for<'a> From<(&'a [&'a Segment<Scalar>], &'a [&'a Segment<Scalar>])>,
     Point<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Point<Scalar>: Orient,
     for<'a> &'a Segment<Scalar>: Bounded<&'a Scalar>,
 {
@@ -165,7 +165,7 @@ where
         + ReduceEvents<Output = Vec<Segment<Scalar>>>
         + for<'a> From<(&'a [&'a Segment<Scalar>], &'a [&'a Segment<Scalar>])>,
     Point<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Point<Scalar>: Orient,
     for<'a> &'a Segment<Scalar>: Bounded<&'a Scalar>,
 {
@@ -196,7 +196,7 @@ where
         + ReduceEvents<Output = Vec<Segment<Scalar>>>
         + for<'a> From<(&'a [&'a Segment<Scalar>], &'a [&'a Polygon<Scalar>])>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Multipolygon<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Multisegment<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Polygon<Scalar>: Bounded<&'a Scalar>,
@@ -292,7 +292,7 @@ where
         + ReduceEvents<Output = Vec<Segment<Scalar>>>
         + for<'a> From<(&'a [&'a Segment<Scalar>], &'a Polygon<Scalar>)>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Multisegment<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Polygon<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Segment<Scalar>: Bounded<&'a Scalar>,
@@ -360,7 +360,7 @@ impl<Scalar> Intersection<&Segment<Scalar>> for &Multisegment<Scalar>
 where
     Scalar: PartialEq,
     Point<Scalar>: Clone + Ord,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Point<Scalar>: Orient,
     for<'a> &'a Segment<Scalar>: Bounded<&'a Scalar>,
 {

--- a/src/geometries/multisegment/symmetric_difference.rs
+++ b/src/geometries/multisegment/symmetric_difference.rs
@@ -61,7 +61,7 @@ where
         + for<'a> From<(&'a [&'a Segment<Scalar>], &'a [&'a Segment<Scalar>])>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
     Segment<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Multisegment<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Segment<Scalar>: Bounded<&'a Scalar>,
 {
@@ -163,7 +163,7 @@ where
         + for<'a> From<(&'a [&'a Segment<Scalar>], &'a [&'a Segment<Scalar>])>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
     Segment<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Contour<Scalar>:
         Bounded<&'a Scalar> + Multisegmental<IndexSegment = Segment<Scalar>>,
     for<'a> &'a Multisegment<Scalar>: Bounded<&'a Scalar>,
@@ -266,7 +266,7 @@ where
         + for<'a> From<(&'a [&'a Segment<Scalar>], &'a Segment<Scalar>)>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
     Segment<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Multisegment<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Segment<Scalar>: Bounded<&'a Scalar>,
 {

--- a/src/geometries/multisegment/union.rs
+++ b/src/geometries/multisegment/union.rs
@@ -63,7 +63,7 @@ where
         + for<'a> From<(&'a [&'a Segment<Scalar>], &'a [&'a Segment<Scalar>])>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
     Segment<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Multisegment<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Segment<Scalar>: Bounded<&'a Scalar>,
 {
@@ -166,7 +166,7 @@ where
         + for<'a> From<(&'a [&'a Segment<Scalar>], &'a [&'a Segment<Scalar>])>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
     Segment<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Contour<Scalar>:
         Bounded<&'a Scalar> + Multisegmental<IndexSegment = Segment<Scalar>>,
     for<'a> &'a Multisegment<Scalar>: Bounded<&'a Scalar>,
@@ -266,7 +266,7 @@ impl<Scalar: PartialEq> Union<&Segment<Scalar>> for &Multisegment<Scalar>
 where
     Point<Scalar>: Clone + Ord,
     Segment<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Multisegment<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Point<Scalar>:
         IntersectCrossingSegments<Output = Point<Scalar>> + Orient,

--- a/src/geometries/polygon/difference.rs
+++ b/src/geometries/polygon/difference.rs
@@ -57,7 +57,7 @@ where
         + ReduceEvents<Output = Vec<Polygon<Scalar>>>
         + for<'a> From<(&'a Polygon<Scalar>, &'a Polygon<Scalar>)>,
     Polygon<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Point<Scalar>: Elemental<Coordinate = &'a Scalar>,
     for<'a> &'a Polygon<Scalar>: Bounded<&'a Scalar>,
 {
@@ -97,7 +97,7 @@ where
         + for<'a> From<(&'a Polygon<Scalar>, &'a [&'a Polygon<Scalar>])>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
     Polygon<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Multipolygon<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Polygon<Scalar>: Bounded<&'a Scalar>,
 {

--- a/src/geometries/polygon/intersection.rs
+++ b/src/geometries/polygon/intersection.rs
@@ -55,7 +55,7 @@ where
     shaped::Operation<Point<Scalar>, INTERSECTION>: Iterator<Item = Event>
         + ReduceEvents<Output = Vec<Polygon<Scalar>>>
         + for<'a> From<(&'a Polygon<Scalar>, &'a Polygon<Scalar>)>,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Point<Scalar>: Elemental<Coordinate = &'a Scalar>,
     for<'a> &'a Polygon<Scalar>: Bounded<&'a Scalar>,
 {
@@ -95,7 +95,7 @@ where
         + ReduceEvents<Output = Vec<Segment<Scalar>>>
         + for<'a> From<(&'a Polygon<Scalar>, &'a [&'a Segment<Scalar>])>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Contour<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Multipolygon<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Polygon<Scalar>: Bounded<&'a Scalar>,
@@ -168,7 +168,7 @@ where
         + ReduceEvents<Output = Vec<Polygon<Scalar>>>
         + for<'a> From<(&'a Polygon<Scalar>, &'a [&'a Polygon<Scalar>])>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Multipolygon<Scalar>: Bounded<&'a Scalar>
         + Multipolygonal<
             IndexPolygon = Polygon<Scalar>,
@@ -234,7 +234,7 @@ where
         + ReduceEvents<Output = Vec<Segment<Scalar>>>
         + for<'a> From<(&'a Polygon<Scalar>, &'a [&'a Segment<Scalar>])>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Multipolygon<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Multisegment<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Polygon<Scalar>: Bounded<&'a Scalar>,
@@ -307,7 +307,7 @@ where
         + ReduceEvents<Output = Vec<Segment<Scalar>>>
         + for<'a> From<(&'a Polygon<Scalar>, &'a Segment<Scalar>)>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Multipolygon<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Polygon<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Segment<Scalar>: Bounded<&'a Scalar>,

--- a/src/geometries/polygon/symmetric_difference.rs
+++ b/src/geometries/polygon/symmetric_difference.rs
@@ -59,7 +59,7 @@ where
         + ReduceEvents<Output = Vec<Polygon<Scalar>>>
         + for<'a> From<(&'a Polygon<Scalar>, &'a Polygon<Scalar>)>,
     Polygon<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Point<Scalar>: Elemental<Coordinate = &'a Scalar>,
     for<'a> &'a Polygon<Scalar>: Bounded<&'a Scalar>,
 {
@@ -98,7 +98,7 @@ where
         + for<'a> From<(&'a Polygon<Scalar>, &'a [&'a Polygon<Scalar>])>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
     Polygon<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Multipolygon<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Polygon<Scalar>: Bounded<&'a Scalar>,
 {

--- a/src/geometries/polygon/union.rs
+++ b/src/geometries/polygon/union.rs
@@ -57,7 +57,7 @@ where
         + ReduceEvents<Output = Vec<Polygon<Scalar>>>
         + for<'a> From<(&'a Polygon<Scalar>, &'a Polygon<Scalar>)>,
     Polygon<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Point<Scalar>: Elemental<Coordinate = &'a Scalar>,
     for<'a> &'a Polygon<Scalar>: Bounded<&'a Scalar>,
 {
@@ -95,7 +95,7 @@ where
         + for<'a> From<(&'a Polygon<Scalar>, &'a [&'a Polygon<Scalar>])>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
     Polygon<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Multipolygon<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Polygon<Scalar>: Bounded<&'a Scalar>,
 {

--- a/src/geometries/segment/difference.rs
+++ b/src/geometries/segment/difference.rs
@@ -61,7 +61,7 @@ impl<Scalar: Ord> Difference for &Segment<Scalar>
 where
     Segment<Scalar>: Clone,
     Point<Scalar>: Clone + PartialOrd,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Point<Scalar>:
         IntersectCrossingSegments<Output = Point<Scalar>> + Orient,
     for<'a> &'a Segment<Scalar>: Bounded<&'a Scalar>,
@@ -152,7 +152,7 @@ where
         + ReduceEvents<Output = Vec<Segment<Scalar>>>
         + for<'a> From<(&'a Segment<Scalar>, &'a [&'a Segment<Scalar>])>,
     Segment<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Contour<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Segment<Scalar>: Bounded<&'a Scalar>,
 {
@@ -214,7 +214,7 @@ where
         + for<'a> From<(&'a Segment<Scalar>, &'a [&'a Polygon<Scalar>])>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
     Segment<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Multipolygon<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Polygon<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Segment<Scalar>: Bounded<&'a Scalar>,
@@ -279,7 +279,7 @@ where
         + ReduceEvents<Output = Vec<Segment<Scalar>>>
         + for<'a> From<(&'a Segment<Scalar>, &'a [&'a Segment<Scalar>])>,
     Segment<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Multisegment<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Segment<Scalar>: Bounded<&'a Scalar>,
 {
@@ -341,7 +341,7 @@ where
         + for<'a> From<(&'a Segment<Scalar>, &'a Polygon<Scalar>)>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
     Segment<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Polygon<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Segment<Scalar>: Bounded<&'a Scalar>,
 {

--- a/src/geometries/segment/intersection.rs
+++ b/src/geometries/segment/intersection.rs
@@ -58,7 +58,7 @@ impl<Scalar> Intersection for &Segment<Scalar>
 where
     Scalar: PartialEq,
     Point<Scalar>: Clone + Ord,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Point<Scalar>: Orient,
     for<'a> &'a Segment<Scalar>: Bounded<&'a Scalar>,
 {
@@ -88,7 +88,7 @@ impl<Scalar> Intersection<&Contour<Scalar>> for &Segment<Scalar>
 where
     Scalar: PartialEq,
     Point<Scalar>: Clone + Ord,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Point<Scalar>: Orient,
     for<'a> &'a Segment<Scalar>: Bounded<&'a Scalar>,
 {
@@ -106,7 +106,7 @@ where
         + ReduceEvents<Output = Vec<Segment<Scalar>>>
         + for<'a> From<(&'a Segment<Scalar>, &'a [&'a Polygon<Scalar>])>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Multisegment<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Multipolygon<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Segment<Scalar>: Bounded<&'a Scalar>,
@@ -176,7 +176,7 @@ impl<Scalar> Intersection<&Multisegment<Scalar>> for &Segment<Scalar>
 where
     Scalar: PartialEq,
     Point<Scalar>: Clone + Ord,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Point<Scalar>: Orient,
     for<'a> &'a Segment<Scalar>: Bounded<&'a Scalar>,
 {
@@ -194,7 +194,7 @@ where
         + ReduceEvents<Output = Vec<Segment<Scalar>>>
         + for<'a> From<(&'a Segment<Scalar>, &'a Polygon<Scalar>)>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Multisegment<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Segment<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Polygon<Scalar>: Bounded<&'a Scalar>,

--- a/src/geometries/segment/symmetric_difference.rs
+++ b/src/geometries/segment/symmetric_difference.rs
@@ -127,7 +127,7 @@ where
         + for<'a> From<(&'a Segment<Scalar>, &'a [&'a Segment<Scalar>])>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
     Segment<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Contour<Scalar>:
         Bounded<&'a Scalar> + Multisegmental<IndexSegment = Segment<Scalar>>,
     for<'a> &'a Segment<Scalar>: Bounded<&'a Scalar>,
@@ -206,7 +206,7 @@ where
         + for<'a> From<(&'a Segment<Scalar>, &'a [&'a Segment<Scalar>])>,
     Point<Scalar>: Elemental<Coordinate = Scalar>,
     Segment<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Multisegment<Scalar>:
         Bounded<&'a Scalar> + Multisegmental<IndexSegment = Segment<Scalar>>,
     for<'a> &'a Segment<Scalar>: Bounded<&'a Scalar>,

--- a/src/geometries/segment/union.rs
+++ b/src/geometries/segment/union.rs
@@ -110,7 +110,7 @@ impl<Scalar: PartialEq> Union<&Contour<Scalar>> for &Segment<Scalar>
 where
     Point<Scalar>: Clone + Ord,
     Segment<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Contour<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Point<Scalar>:
         IntersectCrossingSegments<Output = Point<Scalar>> + Orient,
@@ -138,7 +138,7 @@ impl<Scalar: PartialEq> Union<&Multisegment<Scalar>> for &Segment<Scalar>
 where
     Point<Scalar>: Clone + Ord,
     Segment<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Multisegment<Scalar>: Bounded<&'a Scalar>,
     for<'a> &'a Point<Scalar>:
         IntersectCrossingSegments<Output = Point<Scalar>> + Orient,
@@ -173,7 +173,7 @@ fn unite_segment_with_segments<
 where
     Point<Scalar>: Clone + Ord,
     Segment<Scalar>: Clone,
-    for<'a> &'a Box<&'a Scalar>: Relatable,
+    for<'a, 'b> &'a Box<&'b Scalar>: Relatable,
     for<'a> &'a Point<Scalar>:
         IntersectCrossingSegments<Output = Point<Scalar>> + Orient,
     for<'a> &'a Segment<Scalar>: Bounded<&'a Scalar>,


### PR DESCRIPTION
The current where-bound is weaker than the actual impl. Calling some functions, e.g. `fn to_boxes_have_common_continuum` actually requires using different higher ranked lifetimes for `&Box` and `&Scalar`. Trying to use the where-bounds in this case results in a higher-ranked region error. This previously compiled as we eagerly discarded the where-bounds and used the impls instead. This will stop being the case once https://github.com/rust-lang/rust/pull/119820 lands, breaking your code.

Please ask for clarification if you would like further information. I apologize for the inconvenience.